### PR TITLE
Add guest example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,5 @@ alias MatrixSDK.Client.Request
 ```
 
 This example will retreive the versions of the specification supported by the `matrix.org` homeserver. 
+
+The [examples](examples/) also demonstrate usage and can be executed with e.g.: `mix run examples/guest_login.exs`

--- a/examples/guest_login.exs
+++ b/examples/guest_login.exs
@@ -1,0 +1,58 @@
+alias MatrixSDK.Client
+alias MatrixSDK.Client.Request
+
+require Logger
+
+# Note if the matrix.org server is unresponsive, there will be a timeout error
+# from the HTTP client. 
+Logger.info("Running guest login example...")
+Logger.info("Registering guest user...")
+
+url = "https://matrix.org"
+
+#  This will register a guest account with the matrix.org homeserver and returns
+# a token to be used for subsequent reqeuests.
+{:ok, response} =
+  url
+  |> Request.register_guest()
+  |> Client.do_request()
+
+Logger.debug("Response:")
+IO.inspect(response.body)
+
+token = response.body["access_token"]
+room = "#elixirsdktest:matrix.org"
+
+# Hack: passing the lambda to itslef to be able to use recursion. 
+join_room = fn join_room ->
+  {:ok, response} =
+    url
+    |> Request.join_room(token, room)
+    |> Client.do_request()
+
+  if response.body["errcode"] do
+    IO.gets(
+      "Please accept the matrix.org terms and conditions by opening this link in the browser: #{
+        inspect(response.body["consent_uri"])
+      }, once this is done, press enter to continue:"
+    )
+
+    join_room.(join_room)
+  else
+    Logger.debug("Response:")
+    IO.inspect(response.body)
+  end
+end
+
+Logger.info("Joining #{inspect(room)} room...")
+join_room.(join_room)
+
+Logger.info("Starting sync for room #{inspect(room)}...")
+
+{:ok, response} =
+  url
+  |> Request.sync(token)
+  |> Client.do_request()
+
+Logger.debug("Response:")
+IO.inspect(response.body)

--- a/examples/guest_login.exs
+++ b/examples/guest_login.exs
@@ -10,7 +10,7 @@ Logger.info("Registering guest user...")
 
 url = "https://matrix.org"
 
-#  This will register a guest account with the matrix.org homeserver and returns
+# This will register a guest account with the matrix.org homeserver and returns
 # a token to be used for subsequent reqeuests.
 {:ok, response} =
   url
@@ -39,15 +39,14 @@ join_room = fn join_room ->
 
     join_room.(join_room)
   else
-    Logger.debug("Response:")
-    IO.inspect(response.body)
+    Logger.debug("Response: #{inspect(response.body)}")
   end
 end
 
-Logger.info("Joining #{inspect(room)} room...")
+Logger.info("Joining the #{inspect(room)} room...")
 join_room.(join_room)
 
-Logger.info("Starting sync for room #{inspect(room)}...")
+Logger.info("Starting sync for room: #{inspect(room)}...")
 
 {:ok, response} =
   url


### PR DESCRIPTION
This adds an examples directory with a guest registration/room join/sync. 

The example can be run with `mix run examples/guest_login.exs`