### PR TITLE
Error response parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* feat: introduce error response parsing [#93]
 * doc: start tracking a changelog [#91]
 
+[#93]: https://github.com/niklaslong/matrix-elixir-sdk/pull/93
 [#91]: https://github.com/niklaslong/matrix-elixir-sdk/pull/91
 
 ### Changed

--- a/lib/matrix_sdk/api.ex
+++ b/lib/matrix_sdk/api.ex
@@ -43,25 +43,8 @@ defmodule MatrixSDK.API do
       |> MatrixSDK.API.do_request(request)
   """
   @spec do_request(Request.t()) :: HTTPClient.result() | Error.t()
-  def do_request(request) do
-    request
-    |> http_client().do_request()
-    |> parse_response()
-  end
-
-  # Delegates to the appropriate parser based on the status code.
-  # TODO: introduce successful response parsing and determine what status codes
-  # correspond to error/success. In addition to this, the parser stack should
-  # be configurable. Perhaps something like `parser().strip_response()`?
-  defp parse_response({:ok, response}) do
-    response.status
-    |> Integer.digits()
-    |> List.first()
-    |> case do
-      4 -> Error.for(response)
-      2 -> response
-    end
-  end
+  # TODO: starting to think this API abstraction isn't very useful.
+  def do_request(request), do: http_client().do_request(request)
 
   defp http_client(), do: Application.fetch_env!(:matrix_sdk, :http_client)
 end

--- a/lib/matrix_sdk/api.ex
+++ b/lib/matrix_sdk/api.ex
@@ -1,17 +1,17 @@
 defmodule MatrixSDK.API do
   @moduledoc """
   Provides a wrapper around the `MatrixSDK.HTTPClient` and related configuration. In future it
-  will likely abstract response parsing, error handling and configuration. 
+  will likely abstract response parsing, error handling and configuration.
 
   Requests are represented by a `MatrixSDK.API.Request` struct and executed with a call to
-  `MatrixSDK.API.do_request/1`: 
+  `MatrixSDK.API.do_request/1`:
 
       "https://matrix.org"
       |> MatrixSDK.API.Request.login("token")
       |> MatrixSDK.API.do_request()
 
   For more information on the currently supported endpoints, see the `MatrixSDK.API.Request`
-  module documentation. 
+  module documentation.
 
   ## 3PID API flows
 
@@ -31,10 +31,10 @@ defmodule MatrixSDK.API do
   """
 
   alias MatrixSDK.HTTPClient
-  alias MatrixSDK.API.Request
+  alias MatrixSDK.API.{Request, Error}
 
   @doc """
-  Executes a given request through the configured HTTP client. 
+  Executes a given request through the configured HTTP client.
 
   ## Examples
 
@@ -42,8 +42,26 @@ defmodule MatrixSDK.API do
       |> MatrixSDK.API.Request.sync("token")
       |> MatrixSDK.API.do_request(request)
   """
-  @spec do_request(Request.t()) :: HTTPClient.result()
-  def do_request(request), do: http_client().do_request(request)
+  @spec do_request(Request.t()) :: HTTPClient.result() | Error.t()
+  def do_request(request) do
+    request
+    |> http_client().do_request()
+    |> parse_response()
+  end
+
+  # Delegates to the appropriate parser based on the status code.
+  # TODO: introduce successful response parsing and determine what status codes
+  # correspond to error/success. In addition to this, the parser stack should
+  # be configurable. Perhaps something like `parser().strip_response()`?
+  defp parse_response({:ok, response}) do
+    response.status
+    |> Integer.digits()
+    |> List.first()
+    |> case do
+      4 -> Error.for(response)
+      2 -> response
+    end
+  end
 
   defp http_client(), do: Application.fetch_env!(:matrix_sdk, :http_client)
 end

--- a/lib/matrix_sdk/api/error.ex
+++ b/lib/matrix_sdk/api/error.ex
@@ -1,0 +1,44 @@
+defmodule MatrixSDK.API.Error do
+  @moduledoc """
+  Defines functions and types for parsing 4xx API responses.
+  """
+
+  @enforce_keys [:kind, :message, :status_code]
+  defstruct [
+    :kind,
+    :message,
+    :status_code,
+    :soft_logout,
+    :retry_after_ms,
+    :room_version,
+    :admin_contact
+  ]
+
+  @type t :: %__MODULE__{
+          kind: binary,
+          message: binary,
+          status_code: integer,
+          soft_logout: boolean | nil,
+          retry_after_ms: integer | nil,
+          room_version: binary | nil,
+          admin_contact: binary | nil
+        }
+
+  @doc """
+  Parses a response into an `Error` struct containing the Matrix error kind,
+  the error message and optionaly whether a soft logout has occured.
+  """
+  # TODO: the input type should be more precise, see HTTPClient.
+  @spec for(any) :: t
+  def for(response) do
+    %__MODULE__{
+      kind: response.body["errcode"],
+      message: response.body["error"],
+      status_code: response.status,
+      soft_logout: response.body["soft_logout"],
+      retry_after_ms: response.body["retry_after_ms"],
+      room_version: response.body["room_version"],
+      admin_contact: response.body["admin_contact"]
+    }
+  end
+end

--- a/lib/matrix_sdk/api/error.ex
+++ b/lib/matrix_sdk/api/error.ex
@@ -26,7 +26,9 @@ defmodule MatrixSDK.API.Error do
 
   @doc """
   Parses a response into an `Error` struct containing the Matrix error kind,
-  the error message and optionaly whether a soft logout has occured.
+  the error message and the HTTP status code. Optionally it includes the
+  `soft_logout`, `retry_after_ms`, `room_version` and `admin_contact` fields
+  when applicable.
   """
   # TODO: the input type should be more precise, see HTTPClient.
   @spec for(any) :: t

--- a/lib/matrix_sdk/http_client.ex
+++ b/lib/matrix_sdk/http_client.ex
@@ -6,8 +6,12 @@ defmodule MatrixSDK.HTTPClient do
   use Tesla, docs: false
   alias MatrixSDK.API.Request
 
+  # TODO: for the HTTP client to be configurable the return type needs to be
+  # more generic. Currently all that is needed is a map (or struct) with a
+  # `"status" => ...` and a `"body" => ...`.
   @type result :: Tesla.Env.result()
 
+  # TODO: maybe we should require the HTTPClient to return `API.Response | API.Error`?
   @callback do_request(Request.t()) :: Tesla.Env.result()
 
   def client(base_url, headers \\ []) do

--- a/lib/matrix_sdk/http_client.ex
+++ b/lib/matrix_sdk/http_client.ex
@@ -15,7 +15,7 @@ defmodule MatrixSDK.HTTPClient do
 
   #  TODO: could be private?
   def client(base_url, headers \\ []) do
-    headers = [{"Accept", "application/json'"} | headers]
+    headers = [{"Accept", "application/json"} | headers]
 
     middleware = [
       {Tesla.Middleware.BaseUrl, base_url},

--- a/test/matrix_sdk/api/error_test.exs
+++ b/test/matrix_sdk/api/error_test.exs
@@ -1,0 +1,34 @@
+defmodule MatrixSDK.API.ErrorTest do
+  use ExUnit.Case, async: true
+
+  alias MatrixSDK.API.Error
+  alias Tesla
+
+  describe "for/1:" do
+    test "parses a 4xx HTTP response into an Error" do
+      response = %Tesla.Env{
+        status: 401,
+        body: %{
+          # Testing all the fields here, in reality not all of these will be
+          # present at the same time.
+          "errcode" => "M_UNKNOWN_TOKEN",
+          "error" => "Invalid macaroon passed.",
+          "soft_logout" => false,
+          "retry_after_ms" => 2000,
+          "room_version" => "1",
+          "admin_contact" => "mailto:server.admin@example.org"
+        }
+      }
+
+      error = Error.for(response)
+
+      assert error.kind == response.body["errcode"]
+      assert error.message == response.body["error"]
+      assert error.status_code == response.status
+      assert error.soft_logout == response.body["soft_logout"]
+      assert error.retry_after_ms == response.body["retry_after_ms"]
+      assert error.room_version == response.body["room_version"]
+      assert error.admin_contact == response.body["admin_contact"]
+    end
+  end
+end

--- a/test/matrix_sdk/api_test.exs
+++ b/test/matrix_sdk/api_test.exs
@@ -25,7 +25,7 @@ defmodule MatrixSDK.APITest do
     expect(HTTPClientMock, :do_request, fn %Request{} = request ->
       assert Map.equal?(request, expected_request)
 
-      {:ok, %Tesla.Env{}}
+      {:ok, %Tesla.Env{status: 200}}
     end)
   end
 end

--- a/test/matrix_sdk/http_client_test.exs
+++ b/test/matrix_sdk/http_client_test.exs
@@ -265,7 +265,7 @@ defmodule MatrixSDK.HTTPClientTest do
         )
       end)
 
-      #  Only testing the struct is correct, unit testing field parsing is done
+      # Only testing the struct is correct, unit testing field parsing is done
       # in the `MatrixSDK.API.Error` module.
       assert %Error{} = HTTPClient.do_request(request)
     end

--- a/test/matrix_sdk/http_client_test.exs
+++ b/test/matrix_sdk/http_client_test.exs
@@ -22,7 +22,7 @@ defmodule MatrixSDK.HTTPClientTest do
 
       assert client.pre == [
                {Tesla.Middleware.BaseUrl, :call, [url]},
-               {Tesla.Middleware.Headers, :call, [[{"Accept", "application/json'"}]]},
+               {Tesla.Middleware.Headers, :call, [[{"Accept", "application/json"}]]},
                {Tesla.Middleware.JSON, :call, [[]]}
              ]
     end
@@ -38,7 +38,7 @@ defmodule MatrixSDK.HTTPClientTest do
       assert client.pre == [
                {Tesla.Middleware.BaseUrl, :call, [url]},
                {Tesla.Middleware.Headers, :call,
-                [[{"Accept", "application/json'"}, {"Custom-Header", "value"}]]},
+                [[{"Accept", "application/json"}, {"Custom-Header", "value"}]]},
                {Tesla.Middleware.JSON, :call, [[]]}
              ]
     end


### PR DESCRIPTION
This is a first step in addressing #79. It introduces an `Error` struct converted from `4xx` responses. Many questions still remain open (see `TODO` comments). 