### PR TITLE
Use new elixir setup action

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,18 +13,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      
+
     - name: Setup elixir
-      uses: actions/setup-elixir@v1
+      uses: erlef/setup-elixir@v1
       with:
-        elixir-version: 1.10.2 
+        elixir-version: 1.10.2
         otp-version: 22.2
-  
+
     - name: Install Dependencies
       run: mix deps.get
-    
+
     - name: Run Tests
       run: mix compile && mix test
-    
+
     - name: Check formatting
       run: mix format --check-formatted


### PR DESCRIPTION
Following the archival of the [old action](https://github.com/actions/setup-elixir), this PR introduces the [new gh action for elixir setup](https://github.com/erlef/setup-elixir). 